### PR TITLE
Ln/pr 414 suggested changes

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,22 +1,12 @@
 package cmd
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"testing"
-
 	"github.com/deso-protocol/core/lib"
 	"github.com/golang/glog"
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
 )
-
-// Global variable that determines the max tip blockheight of syncing nodes throughout test cases.
-const MaxSyncBlockHeight = 1500
-
-// Global variable that allows setting node configuration hypersync snapshot period.
-const HyperSyncSnapshotPeriod = 1000
 
 type Config struct {
 	// Core
@@ -229,50 +219,4 @@ func (config *Config) Print() {
 
 	glog.Infof("Rate Limit Feerate: %d", config.RateLimitFeerate)
 	glog.Infof("Min Feerate: %d", config.MinFeerate)
-}
-
-// GenerateTestConfig creates a default config for a node, with provided port, db directory, and number of max peers.
-// It's usually the first step to starting a node.
-func GenerateTestConfig(t *testing.T, port uint32, dataDir string, maxPeers uint32) Config {
-	config := Config{}
-	params := lib.DeSoMainnetParams
-
-	params.DNSSeeds = []string{}
-	config.Params = &params
-	config.ProtocolPort = uint16(port)
-	// "/Users/piotr/data_dirs/n98_1"
-	config.DataDirectory = dataDir
-	if err := os.MkdirAll(config.DataDirectory, os.ModePerm); err != nil {
-		t.Fatalf("Could not create data directories (%s): %v", config.DataDirectory, err)
-	}
-	config.TXIndex = false
-	config.HyperSync = false
-	config.MaxSyncBlockHeight = 0
-	config.ConnectIPs = []string{}
-	config.PrivateMode = true
-	config.GlogV = 0
-	config.GlogVmodule = "*bitcoin_manager*=0,*balance*=0,*view*=0,*frontend*=0,*peer*=0,*addr*=0,*network*=0,*utils*=0,*connection*=0,*main*=0,*server*=0,*mempool*=0,*miner*=0,*blockchain*=0"
-	config.MaxInboundPeers = maxPeers
-	config.TargetOutboundPeers = maxPeers
-	config.StallTimeoutSeconds = 900
-	config.MinFeerate = 1000
-	config.OneInboundPerIp = false
-	config.MaxBlockTemplatesCache = 100
-	config.MaxSyncBlockHeight = 100
-	config.MinBlockUpdateInterval = 10
-	config.SnapshotBlockHeightPeriod = HyperSyncSnapshotPeriod
-	config.MaxSyncBlockHeight = MaxSyncBlockHeight
-	config.SyncType = lib.NodeSyncTypeBlockSync
-	//config.ArchivalMode = true
-
-	return config
-}
-
-func getTestDirectory(t *testing.T, testName string) string {
-	require := require.New(t)
-	dbDir, err := ioutil.TempDir("", testName)
-	if err != nil {
-		require.NoError(err)
-	}
-	return dbDir
 }

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -416,7 +416,7 @@ func (node *Node) GetStatus() (NodeStatus, error) {
 // Used while changing the status of the node
 // Modifying getStatusWithoutLock() and the validateStatus() functions and their tests are hard requirements
 // to add new status codes for the node.
-func validateNodeStatus(status NodeStatus) error {
+func ValidateNodeStatus(status NodeStatus) error {
 	switch status {
 	// Instance of the *Node is created, but not yet initialized using *Node.Start()
 	case NEVERSTARTED:
@@ -437,7 +437,7 @@ func validateNodeStatus(status NodeStatus) error {
 // changes the running status of the node
 // Always use this function to change the status of the node.
 func (node *Node) setStatusWithoutLock(newStatus NodeStatus) error {
-	if err := validateNodeStatus(newStatus); err != nil {
+	if err := ValidateNodeStatus(newStatus); err != nil {
 		return err
 	}
 

--- a/integration_testing/blocksync_test.go
+++ b/integration_testing/blocksync_test.go
@@ -20,8 +20,8 @@ func TestSimpleBlockSync(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
@@ -66,8 +66,8 @@ func TestSimpleSyncRestart(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
@@ -118,9 +118,9 @@ func TestSimpleSyncDisconnectWithSwitchingToNewPeer(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
-	dbDir3 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
+	dbDir3 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 	defer os.RemoveAll(dbDir3)

--- a/integration_testing/blocksync_test.go
+++ b/integration_testing/blocksync_test.go
@@ -20,20 +20,20 @@ func TestSimpleBlockSync(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "block_sync_test")
-	dbDir2 := getTestDirectory(t, "block_sync_test_dir2")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.SyncType = lib.NodeSyncTypeBlockSync
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 	config2.SyncType = lib.NodeSyncTypeBlockSync
 
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)
@@ -66,20 +66,20 @@ func TestSimpleSyncRestart(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_simple_sync_restart")
-	dbDir2 := getTestDirectory(t, "test_simple_sync_restart_2")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.SyncType = lib.NodeSyncTypeBlockSync
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 	config2.SyncType = lib.NodeSyncTypeBlockSync
 
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)
@@ -118,26 +118,26 @@ func TestSimpleSyncDisconnectWithSwitchingToNewPeer(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_simple_sync_disconnect_switch_new_peer")
-	dbDir2 := getTestDirectory(t, "test_simple_sync_disconnect_switch_new_peer_2")
-	dbDir3 := getTestDirectory(t, "test_simple_sync_disconnect_switch_new_peer_3")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
+	dbDir3 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 	defer os.RemoveAll(dbDir3)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.SyncType = lib.NodeSyncTypeBlockSync
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 	config2.SyncType = lib.NodeSyncTypeBlockSync
-	config3 := cmd.GenerateTestConfig(t, 18002, dbDir3, 10)
+	config3 := generateConfig(t, 18002, dbDir3, 10)
 	config3.SyncType = lib.NodeSyncTypeBlockSync
 
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 	config3.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
-	node3 := cmd.NewNode(&config3)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
+	node3 := cmd.NewNode(config3)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)

--- a/integration_testing/hypersync_test.go
+++ b/integration_testing/hypersync_test.go
@@ -20,22 +20,22 @@ func TestSimpleHyperSync(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "simple_hyper_sync")
-	dbDir2 := getTestDirectory(t, "simple_hyper_sync_2")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.SyncType = lib.NodeSyncTypeBlockSync
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 	config2.SyncType = lib.NodeSyncTypeHyperSync
 
 	config1.HyperSync = true
 	config2.HyperSync = true
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)
@@ -69,18 +69,18 @@ func TestHyperSyncFromHyperSyncedNode(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_hyper_synced_node")
-	dbDir2 := getTestDirectory(t, "test_hyper_synced_node_2")
-	dbDir3 := getTestDirectory(t, "test_hyper_synced_node_3")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
+	dbDir3 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 	defer os.RemoveAll(dbDir3)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.SyncType = lib.NodeSyncTypeBlockSync
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 	config2.SyncType = lib.NodeSyncTypeHyperSyncArchival
-	config3 := cmd.GenerateTestConfig(t, 18002, dbDir3, 10)
+	config3 := generateConfig(t, 18002, dbDir3, 10)
 	config3.SyncType = lib.NodeSyncTypeHyperSyncArchival
 
 	config1.HyperSync = true
@@ -88,9 +88,9 @@ func TestHyperSyncFromHyperSyncedNode(t *testing.T) {
 	config3.HyperSync = true
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
-	node3 := cmd.NewNode(&config3)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
+	node3 := cmd.NewNode(config3)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)
@@ -139,13 +139,13 @@ func TestSimpleHyperSyncRestart(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_hyper_sync_restart")
-	dbDir2 := getTestDirectory(t, "test_hyper_sync_restart")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 
 	config1.HyperSync = true
 	config1.SyncType = lib.NodeSyncTypeBlockSync
@@ -153,8 +153,8 @@ func TestSimpleHyperSyncRestart(t *testing.T) {
 	config2.SyncType = lib.NodeSyncTypeHyperSyncArchival
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)
@@ -194,18 +194,18 @@ func TestSimpleHyperSyncDisconnectWithSwitchingToNewPeer(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_hyper_sync_disconnect_switch_peer")
-	dbDir2 := getTestDirectory(t, "test_hyper_sync_disconnect_switch_peer_2")
-	dbDir3 := getTestDirectory(t, "test_hyper_sync_disconnect_switch_peer_3")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
+	dbDir3 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 	defer os.RemoveAll(dbDir3)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.SyncType = lib.NodeSyncTypeBlockSync
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 	config2.SyncType = lib.NodeSyncTypeHyperSyncArchival
-	config3 := cmd.GenerateTestConfig(t, 18002, dbDir3, 10)
+	config3 := generateConfig(t, 18002, dbDir3, 10)
 	config3.SyncType = lib.NodeSyncTypeBlockSync
 
 	config1.HyperSync = true
@@ -214,9 +214,9 @@ func TestSimpleHyperSyncDisconnectWithSwitchingToNewPeer(t *testing.T) {
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 	config3.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
-	node3 := cmd.NewNode(&config3)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
+	node3 := cmd.NewNode(config3)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)
@@ -271,8 +271,8 @@ func TestSimpleHyperSyncDisconnectWithSwitchingToNewPeer(t *testing.T) {
 //	defer os.RemoveAll(dbDir1)
 //	defer os.RemoveAll(dbDir2)
 //
-//	config1 := GenerateTestConfig(t, 18000, dbDir1, 10)
-//	config2 := GenerateTestConfig(t, 18001, dbDir2, 10)
+//	config1 := generateConfig(t, 18000, dbDir1, 10)
+//	config2 := generateConfig(t, 18001, dbDir2, 10)
 //
 //	config1.HyperSync = true
 //	config2.HyperSync = true
@@ -315,13 +315,13 @@ func TestArchivalMode(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_archival_mode")
-	dbDir2 := getTestDirectory(t, "test_archival_mode_2")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 
 	config1.HyperSync = true
 	config2.HyperSync = true
@@ -329,8 +329,8 @@ func TestArchivalMode(t *testing.T) {
 	config1.SyncType = lib.NodeSyncTypeBlockSync
 	config2.SyncType = lib.NodeSyncTypeHyperSyncArchival
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)
@@ -358,16 +358,16 @@ func TestBlockSyncFromArchivalModeHyperSync(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_block_sync_archival")
-	dbDir2 := getTestDirectory(t, "test_block_sync_archival_2")
-	dbDir3 := getTestDirectory(t, "test_block_sync_archival_3")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
+	dbDir3 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 	defer os.RemoveAll(dbDir3)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
-	config3 := cmd.GenerateTestConfig(t, 18002, dbDir3, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
+	config3 := generateConfig(t, 18002, dbDir3, 10)
 
 	config1.HyperSync = true
 	config1.SyncType = lib.NodeSyncTypeBlockSync
@@ -377,9 +377,9 @@ func TestBlockSyncFromArchivalModeHyperSync(t *testing.T) {
 	config3.SyncType = lib.NodeSyncTypeBlockSync
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
-	node3 := cmd.NewNode(&config3)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
+	node3 := cmd.NewNode(config3)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)

--- a/integration_testing/hypersync_test.go
+++ b/integration_testing/hypersync_test.go
@@ -20,8 +20,8 @@ func TestSimpleHyperSync(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
@@ -69,9 +69,9 @@ func TestHyperSyncFromHyperSyncedNode(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
-	dbDir3 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
+	dbDir3 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 	defer os.RemoveAll(dbDir3)
@@ -139,8 +139,8 @@ func TestSimpleHyperSyncRestart(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
@@ -194,9 +194,9 @@ func TestSimpleHyperSyncDisconnectWithSwitchingToNewPeer(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
-	dbDir3 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
+	dbDir3 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 	defer os.RemoveAll(dbDir3)
@@ -266,8 +266,8 @@ func TestSimpleHyperSyncDisconnectWithSwitchingToNewPeer(t *testing.T) {
 //	require := require.New(t)
 //	_ = require
 //
-//	dbDir1 := getTestDirectory(t)
-//	dbDir2 := getTestDirectory(t)
+//	dbDir1 := getDirectory(t)
+//	dbDir2 := getDirectory(t)
 //	defer os.RemoveAll(dbDir1)
 //	defer os.RemoveAll(dbDir2)
 //
@@ -315,8 +315,8 @@ func TestArchivalMode(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
@@ -358,9 +358,9 @@ func TestBlockSyncFromArchivalModeHyperSync(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
-	dbDir3 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
+	dbDir3 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 	defer os.RemoveAll(dbDir3)

--- a/integration_testing/migrations_test.go
+++ b/integration_testing/migrations_test.go
@@ -16,22 +16,22 @@ func TestEncoderMigrations(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_encoder_migration")
-	dbDir2 := getTestDirectory(t, "test_encoder_migration_2")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.SyncType = lib.NodeSyncTypeBlockSync
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 	config2.SyncType = lib.NodeSyncTypeHyperSync
 
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 	config1.HyperSync = true
 	config2.HyperSync = true
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)

--- a/integration_testing/migrations_test.go
+++ b/integration_testing/migrations_test.go
@@ -16,8 +16,8 @@ func TestEncoderMigrations(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 

--- a/integration_testing/mining_test.go
+++ b/integration_testing/mining_test.go
@@ -14,10 +14,10 @@ func TestRegtestMiner(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_regtest_miner")
+	dbDir1 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.SyncType = lib.NodeSyncTypeBlockSync
 	config1.Params = &lib.DeSoTestnetParams
 	config1.MaxSyncBlockHeight = 0
@@ -25,7 +25,7 @@ func TestRegtestMiner(t *testing.T) {
 
 	config1.Regtest = true
 
-	node1 := cmd.NewNode(&config1)
+	node1 := cmd.NewNode(config1)
 	node1 = startNode(t, node1)
 
 	// wait for node1 to sync blocks

--- a/integration_testing/mining_test.go
+++ b/integration_testing/mining_test.go
@@ -14,7 +14,7 @@ func TestRegtestMiner(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 
 	config1 := generateConfig(t, 18000, dbDir1, 10)

--- a/integration_testing/node_test.go
+++ b/integration_testing/node_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNodeIsRunning(t *testing.T) {
-	testDir := getTestDirectory(t)
+	testDir := getDirectory(t)
 	defer os.RemoveAll(testDir)
 
 	testConfig := generateConfig(t, 18000, testDir, 10)
@@ -36,7 +36,7 @@ func TestNodeIsRunning(t *testing.T) {
 }
 
 func TestNodeStatusRunning(t *testing.T) {
-	testDir := getTestDirectory(t)
+	testDir := getDirectory(t)
 	defer os.RemoveAll(testDir)
 
 	testConfig := generateConfig(t, 18000, testDir, 10)
@@ -71,7 +71,7 @@ func TestNodeStatusRunning(t *testing.T) {
 }
 
 func TestNodeSetStatusStopped(t *testing.T) {
-	testDir := getTestDirectory(t)
+	testDir := getDirectory(t)
 	defer os.RemoveAll(testDir)
 
 	testConfig := generateConfig(t, 18000, testDir, 10)
@@ -106,7 +106,7 @@ func TestNodeSetStatusStopped(t *testing.T) {
 // NEVERSTARTED -> RUNNING -> STOP -> RUNNING
 // In each state change it's tested for valid change in status.
 func TestNodeSetStatus(t *testing.T) {
-	testDir := getTestDirectory(t)
+	testDir := getDirectory(t)
 	defer os.RemoveAll(testDir)
 
 	testConfig := generateConfig(t, 18000, testDir, 10)
@@ -199,7 +199,7 @@ func TestNodeSetStatus(t *testing.T) {
 // Tests for *Node.GetStatus()
 // Loads the status of node after node operations and tests its correctness.
 func TestGetStatus(t *testing.T) {
-	testDir := getTestDirectory(t)
+	testDir := getDirectory(t)
 	defer os.RemoveAll(testDir)
 
 	testConfig := generateConfig(t, 18000, testDir, 10)
@@ -260,7 +260,7 @@ func TestValidateNodeStatus(t *testing.T) {
 
 // Stop the node and test whether the internalExitChan fires as expected.
 func TestNodeStop(t *testing.T) {
-	testDir := getTestDirectory(t)
+	testDir := getDirectory(t)
 	defer os.RemoveAll(testDir)
 
 	testConfig := generateConfig(t, 18000, testDir, 10)

--- a/integration_testing/node_test.go
+++ b/integration_testing/node_test.go
@@ -1,7 +1,8 @@
-package cmd
+package integration_testing
 
 import (
 	"fmt"
+	"github.com/deso-protocol/core/cmd"
 	"os"
 	"syscall"
 	"testing"
@@ -11,14 +12,14 @@ import (
 )
 
 func TestNodeIsRunning(t *testing.T) {
-	testDir := getTestDirectory(t, "test_node_is_running")
+	testDir := getTestDirectory(t)
 	defer os.RemoveAll(testDir)
 
-	testConfig := GenerateTestConfig(t, 18000, testDir, 10)
+	testConfig := generateConfig(t, 18000, testDir, 10)
 
 	testConfig.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	testNode := NewNode(&testConfig)
+	testNode := cmd.NewNode(testConfig)
 
 	// expected running status should be false before the node is started
 	require.False(t, testNode.IsRunning())
@@ -35,14 +36,14 @@ func TestNodeIsRunning(t *testing.T) {
 }
 
 func TestNodeStatusRunning(t *testing.T) {
-	testDir := getTestDirectory(t, "test_node_change_running_status")
+	testDir := getTestDirectory(t)
 	defer os.RemoveAll(testDir)
 
-	testConfig := GenerateTestConfig(t, 18000, testDir, 10)
+	testConfig := generateConfig(t, 18000, testDir, 10)
 
 	testConfig.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	testNode := NewNode(&testConfig)
+	testNode := cmd.NewNode(testConfig)
 
 	// Can change the status to RUNNING from the state NEVERSTARTED
 	actualErr := testNode.SetStatusRunning()
@@ -55,7 +56,7 @@ func TestNodeStatusRunning(t *testing.T) {
 	// start the server
 	// Cannot change status to RUNNING while the node is already RUNNING!
 	testNode.Start()
-	expErr := ErrAlreadyStarted
+	expErr := cmd.ErrAlreadyStarted
 	actualErr = testNode.SetStatusRunning()
 	require.ErrorIs(t, actualErr, expErr)
 
@@ -70,18 +71,18 @@ func TestNodeStatusRunning(t *testing.T) {
 }
 
 func TestNodeSetStatusStopped(t *testing.T) {
-	testDir := getTestDirectory(t, "test_node_change_running_status")
+	testDir := getTestDirectory(t)
 	defer os.RemoveAll(testDir)
 
-	testConfig := GenerateTestConfig(t, 18000, testDir, 10)
+	testConfig := generateConfig(t, 18000, testDir, 10)
 
 	testConfig.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	testNode := NewNode(&testConfig)
+	testNode := cmd.NewNode(testConfig)
 
 	// Need to call node.start() to atleast once to be able to change node status
 	// Cannot change status of node which never got initialized in the first place
-	expErr := ErrNodeNeverStarted
+	expErr := cmd.ErrNodeNeverStarted
 	actualErr := testNode.SetStatusStopped()
 	require.ErrorIs(t, actualErr, expErr)
 
@@ -96,7 +97,7 @@ func TestNodeSetStatusStopped(t *testing.T) {
 	// stop the node
 	testNode.Stop()
 
-	expErr = ErrAlreadyStopped
+	expErr = cmd.ErrAlreadyStopped
 	actualErr = testNode.SetStatusStopped()
 	require.ErrorIs(t, actualErr, expErr)
 }
@@ -105,75 +106,75 @@ func TestNodeSetStatusStopped(t *testing.T) {
 // NEVERSTARTED -> RUNNING -> STOP -> RUNNING
 // In each state change it's tested for valid change in status.
 func TestNodeSetStatus(t *testing.T) {
-	testDir := getTestDirectory(t, "test_node_change_running_status")
+	testDir := getTestDirectory(t)
 	defer os.RemoveAll(testDir)
 
-	testConfig := GenerateTestConfig(t, 18000, testDir, 10)
+	testConfig := generateConfig(t, 18000, testDir, 10)
 
 	testConfig.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	testNode := NewNode(&testConfig)
+	testNode := cmd.NewNode(testConfig)
 
 	// Node is in NEVERSTARTED STATE
 
 	// Changing status from NEVERSTARTED to STOPPED
 	// This is an invalid status transition.
 	// Node status cannot needs to transitioned to RUNNING before changing to STOPPED
-	expError := ErrNodeNeverStarted
-	actualError := testNode.SetStatus(STOPPED)
+	expError := cmd.ErrNodeNeverStarted
+	actualError := testNode.SetStatus(cmd.STOPPED)
 	require.ErrorIs(t, actualError, expError)
 
 	// Cannot set the status to NEVERSTARTED,
 	// It's the default value before the Node is initialized.
-	expError = ErrCannotSetToNeverStarted
-	actualError = testNode.SetStatus(NEVERSTARTED)
+	expError = cmd.ErrCannotSetToNeverStarted
+	actualError = testNode.SetStatus(cmd.NEVERSTARTED)
 	require.ErrorIs(t, actualError, expError)
 	// Starting the node.
 	// The current status of the node is RUNNING.
 	testNode.Start()
 	// The status should be changed to RUNNING.
 	// This successfully tests the transition of status from NEVERSTARTED to RUNNING
-	expectedStatus := RUNNING
+	expectedStatus := cmd.RUNNING
 	actualStatus, err := testNode.GetStatus()
 	require.NoError(t, err)
 	require.Equal(t, actualStatus, expectedStatus)
 
 	// Cannot set the status to NEVERSTARTED,
 	// It's the default value before the Node is initialized.
-	expError = ErrCannotSetToNeverStarted
-	actualError = testNode.SetStatus(NEVERSTARTED)
+	expError = cmd.ErrCannotSetToNeverStarted
+	actualError = testNode.SetStatus(cmd.NEVERSTARTED)
 	require.ErrorIs(t, actualError, expError)
 
 	// Cannot expect the Node status to changed from STOPPED to RUNNING,
 	// while it's current state is RUNNING
-	expError = ErrAlreadyStarted
-	actualError = testNode.SetStatus(RUNNING)
+	expError = cmd.ErrAlreadyStarted
+	actualError = testNode.SetStatus(cmd.RUNNING)
 	require.ErrorIs(t, actualError, expError)
 
 	// Stopping the node.
 	// This should transition the Node state from RUNNING to STOPPED.
 	testNode.Stop()
-	expectedStatus = STOPPED
+	expectedStatus = cmd.STOPPED
 	actualStatus, err = testNode.GetStatus()
 	require.NoError(t, err)
 	require.Equal(t, actualStatus, expectedStatus)
 
 	// Cannot set the status to NEVERSTARTED,
 	// It's the default value before the Node is initialized.
-	expError = ErrCannotSetToNeverStarted
-	actualError = testNode.SetStatus(NEVERSTARTED)
+	expError = cmd.ErrCannotSetToNeverStarted
+	actualError = testNode.SetStatus(cmd.NEVERSTARTED)
 	require.ErrorIs(t, actualError, expError)
 
 	// Cannot expect the Node status to changed from NEVERSTARTED to STOPPED,
 	// while it's current state is STOPPED
-	expError = ErrAlreadyStopped
-	actualError = testNode.SetStatus(STOPPED)
+	expError = cmd.ErrAlreadyStopped
+	actualError = testNode.SetStatus(cmd.STOPPED)
 	require.ErrorIs(t, actualError, expError)
 
 	// Changing status from STOPPED to RUNNING
 	testNode.Start()
 	// The following tests validates a successful transition of state from STOP to RUNNING
-	expectedStatus = RUNNING
+	expectedStatus = cmd.RUNNING
 	actualStatus, err = testNode.GetStatus()
 	require.NoError(t, err)
 	require.Equal(t, actualStatus, expectedStatus)
@@ -181,16 +182,16 @@ func TestNodeSetStatus(t *testing.T) {
 
 	// Set the Node status to an invalid status code
 	// protects from the ignorance of adding new status codes to the iota sequence!
-	expError = ErrInvalidNodeStatus
-	actualError = testNode.SetStatus(NodeStatus(3))
+	expError = cmd.ErrInvalidNodeStatus
+	actualError = testNode.SetStatus(cmd.NodeStatus(3))
 	require.ErrorIs(t, actualError, expError)
 
-	expError = ErrInvalidNodeStatus
-	actualError = testNode.SetStatus(NodeStatus(4))
+	expError = cmd.ErrInvalidNodeStatus
+	actualError = testNode.SetStatus(cmd.NodeStatus(4))
 	require.ErrorIs(t, actualError, expError)
 
-	expError = ErrInvalidNodeStatus
-	actualError = testNode.SetStatus(NodeStatus(5))
+	expError = cmd.ErrInvalidNodeStatus
+	actualError = testNode.SetStatus(cmd.NodeStatus(5))
 	require.ErrorIs(t, actualError, expError)
 
 }
@@ -198,17 +199,17 @@ func TestNodeSetStatus(t *testing.T) {
 // Tests for *Node.GetStatus()
 // Loads the status of node after node operations and tests its correctness.
 func TestGetStatus(t *testing.T) {
-	testDir := getTestDirectory(t, "test_load_status")
+	testDir := getTestDirectory(t)
 	defer os.RemoveAll(testDir)
 
-	testConfig := GenerateTestConfig(t, 18000, testDir, 10)
+	testConfig := generateConfig(t, 18000, testDir, 10)
 
 	testConfig.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	testNode := NewNode(&testConfig)
+	testNode := cmd.NewNode(testConfig)
 
 	// Status is set to NEVERSTARTED before the node is started.
-	expectedStatus := NEVERSTARTED
+	expectedStatus := cmd.NEVERSTARTED
 	actualStatus, err := testNode.GetStatus()
 	require.NoError(t, err)
 	require.Equal(t, actualStatus, expectedStatus)
@@ -217,7 +218,7 @@ func TestGetStatus(t *testing.T) {
 	testNode.Start()
 
 	// The status is expected to be RUNNING once the node is started.
-	expectedStatus = RUNNING
+	expectedStatus = cmd.RUNNING
 	actualStatus, err = testNode.GetStatus()
 	require.NoError(t, err)
 	require.Equal(t, actualStatus, expectedStatus)
@@ -226,44 +227,47 @@ func TestGetStatus(t *testing.T) {
 	testNode.Stop()
 
 	// The status is expected to be STOPPED once the node is stopped.
-	expectedStatus = STOPPED
+	expectedStatus = cmd.STOPPED
 	actualStatus, err = testNode.GetStatus()
 	require.NoError(t, err)
 	require.Equal(t, actualStatus, expectedStatus)
 
 	// set an invalid status
-	wrongStatus := NodeStatus(5)
-	testNode.status = &wrongStatus
-
-	// expect error and invalid status code
-	expectedStatus = INVALIDNODESTATUS
-	actualStatus, err = testNode.GetStatus()
-	require.ErrorIs(t, err, ErrInvalidNodeStatus)
-	require.Equal(t, actualStatus, expectedStatus)
+	wrongStatus := cmd.NodeStatus(5)
+	err = testNode.SetStatus(wrongStatus)
+	require.Error(t, err)
+	// Commenting this out as I can't set a wrong status
+	// maybe there's a way to do this to get more coverage,
+	// but I'd rather have everything in the integration testing file
+	//// expect error and invalid status code
+	//expectedStatus = cmd.INVALIDNODESTATUS
+	//actualStatus, err = testNode.GetStatus()
+	//require.ErrorIs(t, err, cmd.ErrInvalidNodeStatus)
+	//require.Equal(t, actualStatus, expectedStatus)
 }
 
 func TestValidateNodeStatus(t *testing.T) {
 
-	inputs := []NodeStatus{NEVERSTARTED, RUNNING, STOPPED, NodeStatus(3), NodeStatus(4)}
-	errors := []error{nil, nil, nil, ErrInvalidNodeStatus, ErrInvalidNodeStatus}
+	inputs := []cmd.NodeStatus{cmd.NEVERSTARTED, cmd.RUNNING, cmd.STOPPED, cmd.NodeStatus(3), cmd.NodeStatus(4)}
+	errors := []error{nil, nil, nil, cmd.ErrInvalidNodeStatus, cmd.ErrInvalidNodeStatus}
 
 	var err error
 	for i := 0; i < len(inputs); i++ {
-		err = validateNodeStatus(inputs[i])
+		err = cmd.ValidateNodeStatus(inputs[i])
 		require.ErrorIs(t, err, errors[i])
 	}
 }
 
 // Stop the node and test whether the internalExitChan fires as expected.
 func TestNodeStop(t *testing.T) {
-	testDir := getTestDirectory(t, "test_load_status")
+	testDir := getTestDirectory(t)
 	defer os.RemoveAll(testDir)
 
-	testConfig := GenerateTestConfig(t, 18000, testDir, 10)
+	testConfig := generateConfig(t, 18000, testDir, 10)
 
 	testConfig.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	testNode := NewNode(&testConfig)
+	testNode := cmd.NewNode(testConfig)
 	testNode.Start()
 
 	// stop the node

--- a/integration_testing/rollback_test.go
+++ b/integration_testing/rollback_test.go
@@ -15,8 +15,8 @@ func TestStateRollback(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 

--- a/integration_testing/rollback_test.go
+++ b/integration_testing/rollback_test.go
@@ -15,14 +15,14 @@ func TestStateRollback(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "get_state_rollback")
-	dbDir2 := getTestDirectory(t, "get_state_rollback_2")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.SyncType = lib.NodeSyncTypeBlockSync
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 	config2.SyncType = lib.NodeSyncTypeBlockSync
 
 	config1.MaxSyncBlockHeight = 5000
@@ -32,8 +32,8 @@ func TestStateRollback(t *testing.T) {
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 	config2.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)

--- a/integration_testing/tools.go
+++ b/integration_testing/tools.go
@@ -42,7 +42,7 @@ const MaxSyncBlockHeight = 1500
 const HyperSyncSnapshotPeriod = 1000
 
 // get a random temporary directory.
-func getTestDirectory(t *testing.T) string {
+func getDirectory(t *testing.T) string {
 	require := require.New(t)
 	dbDir, err := ioutil.TempDir("", t.Name())
 	if err != nil {

--- a/integration_testing/txindex_test.go
+++ b/integration_testing/txindex_test.go
@@ -20,15 +20,15 @@ func TestSimpleTxIndex(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t, "test_simple_tx_index")
-	dbDir2 := getTestDirectory(t, "test_simple_tx_index_2")
+	dbDir1 := getTestDirectory(t)
+	dbDir2 := getTestDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 
-	config1 := cmd.GenerateTestConfig(t, 18000, dbDir1, 10)
+	config1 := generateConfig(t, 18000, dbDir1, 10)
 	config1.HyperSync = true
 	config1.SyncType = lib.NodeSyncTypeBlockSync
-	config2 := cmd.GenerateTestConfig(t, 18001, dbDir2, 10)
+	config2 := generateConfig(t, 18001, dbDir2, 10)
 	config2.HyperSync = true
 	config2.SyncType = lib.NodeSyncTypeHyperSyncArchival
 
@@ -36,8 +36,8 @@ func TestSimpleTxIndex(t *testing.T) {
 	config2.TXIndex = true
 	config1.ConnectIPs = []string{"deso-seed-2.io:17000"}
 
-	node1 := cmd.NewNode(&config1)
-	node2 := cmd.NewNode(&config2)
+	node1 := cmd.NewNode(config1)
+	node2 := cmd.NewNode(config2)
 
 	node1 = startNode(t, node1)
 	node2 = startNode(t, node2)

--- a/integration_testing/txindex_test.go
+++ b/integration_testing/txindex_test.go
@@ -20,8 +20,8 @@ func TestSimpleTxIndex(t *testing.T) {
 	require := require.New(t)
 	_ = require
 
-	dbDir1 := getTestDirectory(t)
-	dbDir2 := getTestDirectory(t)
+	dbDir1 := getDirectory(t)
+	dbDir2 := getDirectory(t)
 	defer os.RemoveAll(dbDir1)
 	defer os.RemoveAll(dbDir2)
 


### PR DESCRIPTION
@hackintoshrao - I think we can achieve almost all of what you did without changing as much code in existing files, which was my main takeaway in my last review. 

What I changed:
1. move node_test.go into integration_testing package
2. move generateTestConfig and getTestDirectory into integration_testing package in tools.go and renamed back to original names. generateDirectory now uses `t.Name()` to get the name of the test so we don't have to change the function signature. generateConfig returns a pointer to the Config struct now like it currently does in core.
3. made validateNodeStatus a public function so we can access it from integration_testing package

The only piece I commented out is in `TestGetStatus` - I couldn't set the status of the node to an invalid status with any public methods.

Let me know what you think - this will make it easier for us to get this change in as it's much easier to get approval from diamondhands. you can see how much simpler the diff is [here](https://github.com/deso-protocol/core/compare/ln/pr-414-suggested-changes?expand=1)